### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/Mistikan/bitmagnet-comparer/releases/tag/v0.1.0) - 2025-05-20
+
+### Added
+
+- init
+
+### Other
+
+- Merge pull request #3 from Mistikan/dependabot/github_actions/docker/login-action-3
+- *(deps)* bump docker/build-push-action from 5 to 6
+- Initial commit


### PR DESCRIPTION



## 🤖 New release

* `bitmagnet-comparer`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/Mistikan/bitmagnet-comparer/releases/tag/v0.1.0) - 2025-05-20

### Added

- init

### Other

- Merge pull request #3 from Mistikan/dependabot/github_actions/docker/login-action-3
- *(deps)* bump docker/build-push-action from 5 to 6
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).