### PR TITLE
chore: release v0.1.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/Mistikan/bitmagnet-comparer/compare/v0.1.0...v0.1.1) - 2025-05-21
+
+### Other
+
+- *(docker)* fix envs
+
 ## [0.1.0](https://github.com/Mistikan/bitmagnet-comparer/releases/tag/v0.1.0) - 2025-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitmagnet-comparer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmagnet-comparer"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sergei Ermeikin <sereja.ermeikin@gmail.com>"]
 edition = "2024"
 description = "Utility for extracting hashes from bitmagnet and outputting them to the console"


### PR DESCRIPTION



## 🤖 New release

* `bitmagnet-comparer`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/Mistikan/bitmagnet-comparer/compare/v0.1.0...v0.1.1) - 2025-05-21

### Other

- *(docker)* fix envs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).